### PR TITLE
Rename chcp_code to windows_codepage

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -288,7 +288,7 @@ def _run(
     bg=False,
     encoded_cmd=False,
     success_retcodes=None,
-    chcp_code=437,
+    windows_codepage=437,
     **kwargs
 ):
     """
@@ -342,8 +342,8 @@ def _run(
             raise CommandExecutionError(msg)
     elif use_vt:  # Memozation so not much overhead
         raise CommandExecutionError("VT not available on windows")
-    elif chcp_code is not None:
-        salt.utils.chcp.chcp(chcp_code)
+    elif windows_codepage is not None:
+        salt.utils.chcp.chcp(windows_codepage)
 
     if shell.lower().strip() == "powershell":
         # Strip whitespace


### PR DESCRIPTION
Unix admins might not place `chcp` into Windows context and be confused.

