### PR TITLE
document the codepage parameter

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1138,6 +1138,14 @@ def run(
 
       .. versionadded:: 2019.2.0
 
+    :param int windows_codepage: 65001
+        Only apllies to Windows: the `C:\Windows\System32\chcp.com` command is used to 
+        verify or ensure the code page is set before the command `cmd` is executed. 
+        Code page 65001 corresponds with UTF-8 and allows international localization of Windows.
+
+      .. versionadded:: 3002
+
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1139,8 +1139,8 @@ def run(
       .. versionadded:: 2019.2.0
 
     :param int windows_codepage: 65001
-        Only apllies to Windows: the `C:\Windows\System32\chcp.com` command is used to 
-        verify or ensure the code page is set before the command `cmd` is executed. 
+        Only applies to Windows: the minion uses `C:\Windows\System32\chcp.com` to 
+        verify or set the code page before he excutes the command `cmd`. 
         Code page 65001 corresponds with UTF-8 and allows international localization of Windows.
 
       .. versionadded:: 3002


### PR DESCRIPTION
### Documents the codepage parameter in run()

WIP: 
- how do we name that thing?
- copy and paste to all the other functions based on _run()...